### PR TITLE
Fix JFileChooser parent to avoid GUI exception

### DIFF
--- a/DatCon/src/apps/DatCon.java
+++ b/DatCon/src/apps/DatCon.java
@@ -323,7 +323,9 @@ public class DatCon extends JPanel
             fc.setSelectedFile(inputFile);
         }
         try {
-            int returnVal = fc.showOpenDialog(this);
+            // Use the application frame as the parent component to avoid
+            // IllegalComponentStateException when the panel is not yet visible
+            int returnVal = fc.showOpenDialog(frame);
             if (returnVal == JFileChooser.APPROVE_OPTION) {
                 File iFile = fc.getSelectedFile();
                 setDatFile(iFile);
@@ -594,7 +596,9 @@ public class DatCon extends JPanel
             } else if (source == outputDirTextField) {
                 if (outputDir != null)
                     dc.setSelectedFile(outputDir);
-                int returnVal = dc.showOpenDialog(this);
+                // Use the application frame as the parent component to avoid
+                // IllegalComponentStateException when the panel is not yet visible
+                int returnVal = dc.showOpenDialog(frame);
                 if (returnVal == JFileChooser.APPROVE_OPTION) {
                     setOutputDir(dc.getSelectedFile());
                     Persist.outputDirName = outputDirName;


### PR DESCRIPTION
## Summary
- avoid `IllegalComponentStateException` on macOS by using the main `JFrame` as the parent for `JFileChooser`

## Testing
- `javac --release 8 -classpath DatCon/lib/ia_math.jar -d bin $(find DatCon/src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_684c5192d0e4832cb405a7d4c22da23b